### PR TITLE
feat: add redirection after login and logout

### DIFF
--- a/src/protect/getData.php
+++ b/src/protect/getData.php
@@ -3,11 +3,6 @@ session_start();
 
 header('Content-Type: application/json; charset=utf-8');
 
-// TODO('remove this')
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
-
 require_once __DIR__ . '/../../php/vendor/autoload.php';
 require_once __DIR__ . '/src/DataResponse.php';
 require_once __DIR__ . '/../../php/auth-config.php';

--- a/src/protect/login.php
+++ b/src/protect/login.php
@@ -8,11 +8,6 @@ require_once __DIR__ . '/../../php/auth-config.php';
 use Eirbware\Protect\LoginResponse;
 use Jumbojett\OpenIDConnectClient;
 
-// TODO('remove this')
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
-
 $redirect = null;
 if (isset($_SESSION['protect_redirect'])) {
     $redirect = $_SESSION['protect_redirect'];

--- a/src/protect/login.php
+++ b/src/protect/login.php
@@ -1,8 +1,6 @@
 <?php
 session_start();
 
-header('Content-Type: application/json; charset=utf-8');
-
 require_once __DIR__ . '/../../php/vendor/autoload.php';
 require_once __DIR__ . '/src/LoginResponse.php';
 require_once __DIR__ . '/../../php/auth-config.php';
@@ -15,9 +13,20 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
+$redirect = null;
+if (isset($_SESSION['protect_redirect'])) {
+    $redirect = $_SESSION['protect_redirect'];
+}
+if (isset($_GET['redirect'])) {
+    $redirect = $_GET['redirect'];
+    $_SESSION['protect_redirect'] = $redirect;
+}
+
+
 if (isset($_SESSION['cas_data']) && $_SESSION['cas_data'] != "") {
     $response = new LoginResponse(TRUE, "User already connected", $_SESSION);
-    echo $response->toString();
+    $response->send($redirect);
+    $_SESSION['protect_redirect'] = null;
     exit();
 }
 
@@ -34,7 +43,8 @@ try {
     $openIdClient->authenticate();
 } catch (Jumbojett\OpenIDConnectClientException $e) {
     $response = new LoginResponse(FALSE, $e->getMessage(), $_SESSION);
-    echo $response->toString();
+    $response->send($redirect);
+    $_SESSION['protect_redirect'] = null;
     exit(0);
 }
 
@@ -43,19 +53,22 @@ try {
     $userInfo = $openIdClient->requestUserInfo();
 } catch (Jumbojett\OpenIDConnectClientException $e) {
     $response = new LoginResponse(FALSE, $e->getMessage(), $_SESSION);
-    echo $response->toString();
+    $response->send($redirect);
+    $_SESSION['protect_redirect'] = null;
     exit(0);
 }
 
 if (!isset($userInfo->uid)) {
     $response = new LoginResponse(FALSE, "Login failed for unknown reason", $_SESSION);
-    echo $response->toString();
+    $response->send($redirect);
+    $_SESSION['protect_redirect'] = null;
     exit(0);
 }
 
 $_SESSION['cas_data'] = $userInfo;
 
 $response = new LoginResponse(TRUE, "Login successful", $_SESSION);
-echo $response->toString();
+$response->send($redirect);
+$_SESSION['protect_redirect'] = null;
 
 ?>

--- a/src/protect/logout.php
+++ b/src/protect/logout.php
@@ -5,4 +5,10 @@ session_start();
 
 session_unset();
 session_destroy();
+
+if (isset($_GET['redirect'])) {
+    header('Location :' . $_GET['redirect']);
+} else {
+    header('Location : /');
+}
 ?>

--- a/src/protect/src/LoginResponse.php
+++ b/src/protect/src/LoginResponse.php
@@ -16,6 +16,16 @@ class LoginResponse {
     function toString(): string {
         return json_encode($this);
     }
+
+    function send(?string $redirect = null) {
+        if (isset($redirect)) {
+            // TODO('transfer error message to client if login failed?')
+            header('Location: ' . $redirect);
+        } else {
+            header('Content-Type: application/json; charset=utf-8');
+            echo $this->toString();
+        }
+    }
 }
 
 ?>


### PR DESCRIPTION
Redirect location is provided via the `redirect` GET parameter.

If no location is provided, the login page will echo a json response instead and the logout page will redirect to the site's root.