### PR TITLE
feat: Add protected links

### DIFF
--- a/auth-config.example.php
+++ b/auth-config.example.php
@@ -17,6 +17,6 @@ $OPENID_CONFIG = [
 $PROTECTED_DATA = [
     "message" =>"Je suis protégé !",
     "video" => "https://www.youtube.com/watch?v=xvFZjo5PgG0",
-    "theme_du_wei" => "wei.eirb.fr"
+    "theme_du_wei" => "https://wei.eirb.fr"
 ];
 ?>

--- a/auth-config.example.php
+++ b/auth-config.example.php
@@ -13,6 +13,13 @@ $OPENID_CONFIG = [
     "redirect_url" => "http://localhost:8080/protect/login.php"
 ];
 
+// Protected links accessible through `/protect/links.php?name=<link-name>` when authentified
+// URLs listed here must be valid according to RFC 2396 and start with http (or https)
+$PROTECTED_LINKS = [
+    "video" => "https://www.youtube.com/watch?v=xvFZjo5PgG0",
+    "url_pas_valide" => "example.org"
+];
+
 // Protected data to return on site authentication (can be a string, an array..)
 $PROTECTED_DATA = [
     "message" =>"Je suis protégé !",

--- a/src/index.html
+++ b/src/index.html
@@ -34,15 +34,37 @@ function data_button2()
 document.getElementById("login").onclick = () => protect.login();
 document.getElementById("get-data").onclick = () => data_button();
 document.getElementById("get-data2").onclick = () => data_button2();
+document.getElementById("redirect").onclick = () => protect.redirect("video");
+document.getElementById("redirect2").onclick = () => protect.redirect("theme_du_wei");
 document.getElementById("logout").onclick = () => protect.logout();
 </script>
 </head>
 <body>
     <h1>Demo protect by Eirbware</h1>
 
-    <button id="login">Login</button>
-    <button id="get-data">Voir les données</button>
-    <button id="get-data2">Voir les données mais login si fail</button>
-    <button id="logout">Logout</button>
+    <section id="js">
+        <h2>Avec js</h2>
+
+        <div>
+            <button id="login">Login</button>
+            <button id="get-data">Voir les données</button>
+            <button id="get-data2">Voir les données mais login si fail</button>
+            <button id="redirect">Vidéo de liste</button>
+            <button id="redirect2">Téma le thème du wei</button>
+            <button id="logout">Logout</button>
+        </div>
+    </section>
+
+    <section id="nojs">
+        <h2>Sans js</h2>
+
+        <p>La seule feature qui a du sens sans js est la redirection</p>
+
+        <div>
+            <a href="/protect/link.php?name=video">Vidéo de liste</a>
+            <a href="/protect/link.php?name=theme_du_wei">Téma le thème du wei</a>
+        </div>
+    </section>
+
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -35,7 +35,8 @@ document.getElementById("login").onclick = () => protect.login();
 document.getElementById("get-data").onclick = () => data_button();
 document.getElementById("get-data2").onclick = () => data_button2();
 document.getElementById("redirect").onclick = () => protect.redirect("video");
-document.getElementById("redirect2").onclick = () => protect.redirect("theme_du_wei");
+document.getElementById("redirect2").onclick = () => protect.redirect("url_pas_valide");
+document.getElementById("redirect3").onclick = () => protect.redirect("doesntexist");
 document.getElementById("logout").onclick = () => protect.logout();
 </script>
 </head>
@@ -50,7 +51,8 @@ document.getElementById("logout").onclick = () => protect.logout();
             <button id="get-data">Voir les données</button>
             <button id="get-data2">Voir les données mais login si fail</button>
             <button id="redirect">Vidéo de liste</button>
-            <button id="redirect2">Téma le thème du wei</button>
+            <button id="redirect2">Lien non valide</button>
+            <button id="redirect3">Lien non défini</button>
             <button id="logout">Logout</button>
         </div>
     </section>
@@ -62,7 +64,9 @@ document.getElementById("logout").onclick = () => protect.logout();
 
         <div>
             <a href="/protect/link.php?name=video">Vidéo de liste</a>
-            <a href="/protect/link.php?name=theme_du_wei">Téma le thème du wei</a>
+            <a href="/protect/link.php?name=url_pas_valide">Lien non valide</a>
+            <a href="/protect/link.php?name=doesntexist">Lien non défini</a>
+            <a href="/protect/link.php">Absence query</a>
         </div>
     </section>
 

--- a/src/lib/protect.js
+++ b/src/lib/protect.js
@@ -37,8 +37,18 @@ function logout(redirect = window.location.origin) {
 }
 
 
+/*
+ * Redirect the browser to logout page. After logout, the browser redirects by
+ * default to '/'.
+ */
+function redirect(redirectId) {
+    window.location = `/protect/link.php?name=${redirectId}`;
+}
+
+
 export default {
     login,
     getData,
     logout,
+    redirect,
 };

--- a/src/protect/link.php
+++ b/src/protect/link.php
@@ -3,10 +3,7 @@ session_start();
 
 header('Content-Type: application/json; charset=utf-8');
 
-require_once __DIR__ . '/../../php/vendor/autoload.php';
 require_once __DIR__ . '/../../php/auth-config.php';
-
-use Eirbware\Protect\DataResponse;
 
 /* If not logged in, redirect user to login page */
 if (!isset($_SESSION['cas_data']) || $_SESSION['cas_data'] == "") {

--- a/src/protect/link.php
+++ b/src/protect/link.php
@@ -1,0 +1,31 @@
+<?php
+session_start();
+
+header('Content-Type: application/json; charset=utf-8');
+
+require_once __DIR__ . '/../../php/vendor/autoload.php';
+require_once __DIR__ . '/../../php/auth-config.php';
+
+use Eirbware\Protect\DataResponse;
+
+/* If not logged in, redirect user to login page */
+if (!isset($_SESSION['cas_data']) || $_SESSION['cas_data'] == "") {
+    header('Location: login.php?redirect=' . urlencode($_SERVER['REQUEST_URI']));
+    exit();
+}
+
+/* Check for required parameters */
+if (!isset($_GET['name'])) {
+    http_response_code(400);
+    exit();
+}
+
+/* Check that data with this name exists */
+if (!isset($PROTECTED_DATA[$_GET['name']])) {
+    http_response_code(404);
+    exit();
+}
+
+header('Location: ' . $PROTECTED_DATA[$_GET['name']]);
+
+?>

--- a/src/protect/link.php
+++ b/src/protect/link.php
@@ -5,24 +5,27 @@ header('Content-Type: application/json; charset=utf-8');
 
 require_once __DIR__ . '/../../php/auth-config.php';
 
-/* If not logged in, redirect user to login page */
-if (!isset($_SESSION['cas_data']) || $_SESSION['cas_data'] == "") {
-    header('Location: login.php?redirect=' . urlencode($_SERVER['REQUEST_URI']));
-    exit();
-}
-
 /* Check for required parameters */
 if (!isset($_GET['name'])) {
     http_response_code(400);
     exit();
 }
 
-/* Check that data with this name exists */
-if (!isset($PROTECTED_DATA[$_GET['name']])) {
+/* If not logged in, redirect user to login page */
+if (!isset($_SESSION['cas_data']) || $_SESSION['cas_data'] == "") {
+    header('Location: login.php?redirect=' . urlencode($_SERVER['REQUEST_URI']));
+    exit();
+}
+
+/* Check that data with this name exists and is a valid URL */
+$link = $PROTECTED_LINKS[$_GET['name']];
+if (!isset($link)
+    || !filter_var($link, FILTER_VALIDATE_URL)
+    || !str_starts_with($link, "http")) {
     http_response_code(404);
     exit();
 }
 
-header('Location: ' . $PROTECTED_DATA[$_GET['name']]);
+header('Location: ' . $link);
 
 ?>


### PR DESCRIPTION
To protect a link, register it in `auth_config.php`.

Example :
```php
$PROTECTED_LINKS = [
    "super_secret_link" => "https://example.org"
];
```

The link `example.org` can now be hidden behind authentication and is accessible at URL `/protect/link.php?name=super_secret_link`.

All links listed here must be valid URLs according to [RFC 2396](https://datatracker.ietf.org/doc/html/rfc2396) and start with `http` or `https`.